### PR TITLE
regex: Fix negative sets capturing newlines

### DIFF
--- a/filecheck/compiler.py
+++ b/filecheck/compiler.py
@@ -75,5 +75,7 @@ def compile_uops(
         elif isinstance(uop, NumSubst):
             # we don't do numerical substitutions yet
             raise NotImplementedError("Numerical substitutions not supported!")
-
-    return re.compile("".join(expr)), captures
+    try:
+        return re.compile("".join(expr)), captures
+    except re.error:
+        raise CheckError(f"Malformed regex expression: '{''.join(expr)}'", check)

--- a/tests/filecheck/regex.test
+++ b/tests/filecheck/regex.test
@@ -5,3 +5,9 @@ sample text with a number: 144
 
 sample text with another number: 12*12
 // CHECK: sample text with another number: {{([:digit:]{2})}}*{{([:digit:]{2})}}
+
+// make sure that negative capturing groups don't capture newlines
+test 123
+// CHECK: test [[VAR:[^ ,]+]]
+test 123, 123
+// CHECK: test [[VAR]], [[VAR]]


### PR DESCRIPTION
LLVMs `llvm::Regex` has the following flag enabled on all FileCheck regex matches:


> enum llvm::Regex::RegexFlags::Newline = 2U
> Compile for newline-sensitive matching. With this flag '[^' bracket
> expressions and '.' never match newline. A ^ anchor matches the
> null string after any newline in the string in addition to its normal
> function, and the $ anchor matches the null string before any
> newline in the string in addition to its normal function.

This means that `[^ ,]`, combined with this flag, is actually equivalent to `[^\n ,]` in python. Since python doesn't have a flag like this, we approximate this through a best-effort patch that tries to add `\n` to negative sets in the regexes as part of the regex translation.

This is not a good fix imho, as it will break on regexes where `[^` appears inside a set, but that should be sufficiently rare that it won't happen :crossed_fingers: 