### PR TITLE
regex: Syntax fixes for a bunch of stuff (fixes #4, #12)

### DIFF
--- a/filecheck/regex.py
+++ b/filecheck/regex.py
@@ -5,15 +5,14 @@ POSIX_REGEXP_PATTERN = re.compile(
     r"\[:(alpha|upper|lower|digit|alnum|xdigit|space|blank|print|punct|graph|word|ascii|cntrl):]"
 )
 POSIX_REGEXP_REPLACEMENTS = {
-    "alpha": "[A-Za-z]",
-    "upper": "[A-Z]",
-    "lower": "[a-z]",
-    "digit": "[0-9]",
-    "alnum": "[A-Za-z0-9]",
-    "xdigit": "[A-Fa-f0-9]",
+    "alpha": "A-Za-z",
+    "upper": "A-Z",
+    "lower": "a-z",
+    "digit": "0-9",
+    "alnum": "A-Za-z0-9",
+    "xdigit": "A-Fa-f0-9",
     "space": r"\s",
-    "blank": r"[ \t]",
-    "word": r"\w+",
+    "blank": r" \t",
 }
 
 NEGATED_SET_WITHOUT_NEWLINES = re.compile(r"([^\\]|^)\[\^((?!\\n))")

--- a/tests/filecheck/regex.test
+++ b/tests/filecheck/regex.test
@@ -4,7 +4,7 @@ sample text with a number: 144
 // CHECK: sample text with a number: {{\d+}}
 
 sample text with another number: 12*12
-// CHECK: sample text with another number: {{([:digit:]{2})}}*{{([:digit:]{2})}}
+// CHECK: sample text with another number: {{([[:digit:]]{2})}}*{{([[:digit:]]{2})}}
 
 // make sure that negative capturing groups don't capture newlines
 test 123

--- a/tests/filecheck/variables.test
+++ b/tests/filecheck/variables.test
@@ -24,7 +24,7 @@ print z
 
 // check for posix style regex
 same FF77 FF77
-// CHECK: [[VAR:[:xdigit:]+]] [[VAR]]
+// CHECK: [[VAR:[[:xdigit:]]+]] [[VAR]]
 
 // numeric captures:
 print 0xFF00FF00
@@ -42,3 +42,10 @@ commutativity states that (x * y) = (y * x)
 // CHECK: ([[a:(\w+)(x?)]] * [[b:(\w+)(x?)]]) = ([[b]] * [[a]])
 again: (x * y) = (y * x)
 // CHECK: ([[a]] * [[b]]) = ([[b]] * [[a]])
+
+
+// check that we parse ambigous syntax correctly:
+test %arg1
+// CHECK:       test [[ARG:%[[:alnum:]]+]]
+test [%arg1][0]
+// CHECK-NEXT:  test [[[ARG]]][0]


### PR DESCRIPTION
This fixes both #4 (now correctly replaces `[[:alpha:][:num:]]+` with `[A-Za-z0-9]+`) as well as #12.