### PR TITLE
core: Warn on empty captures instead of throwing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # filecheck - A Python-native clone of LLVMs FileCheck tool
 
-This tries to be as close a clone of LLVMs FileCheck as possible, without going crazy. It currently passes 1530 out of
-1645 (93%) of LLVMs MLIR filecheck tests.
+This tries to be as close a clone of LLVMs FileCheck as possible, without going crazy. It currently passes 1555 out of
+1645 (94.5%) of LLVMs MLIR filecheck tests.
 
 There are some features that are left out for now (e.g.a
 [pseudo-numeric variables](https://llvm.org/docs/CommandGuide/FileCheck.html#filecheck-pseudo-numeric-variables) and

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Here's an overview of all FileCheck features and their implementation status.
   - [ ] `--color` No color support yet
 - **Base Features:**
   - [X] Regex patterns (Bugs: [#7](https://github.com/AntonLydike/filecheck/issues/7), [#9](https://github.com/AntonLydike/filecheck/issues/9))
-  - [X] Captures and Capture Matches (Diverges: [#5](https://github.com/AntonLydike/filecheck/issues/5), Bug: [#11](https://github.com/AntonLydike/filecheck/issues/11))
+  - [X] Captures and Capture Matches (Bug: [#11](https://github.com/AntonLydike/filecheck/issues/11))
   - [X] Numeric Captures
   - [ ] Numeric Substitutions (jesus christ, wtf man)
   - [X] Literal matching (`CHECK{LITERAL}`)
@@ -112,3 +112,8 @@ can be enabled through the environment variable `FILECHECK_FEATURE_ENABLE=...`. 
 
 - `MLIR_REGEX_CLS`: Add additional special regex matchers to match MLIR/LLVM constructs:
   - `\V` will match any SSA value name
+
+### Reject Empty Matches
+
+We introduce a new flag called `reject-empty-vars` that throws an error when a capture expression captures an empty
+string.

--- a/filecheck/colors.py
+++ b/filecheck/colors.py
@@ -1,0 +1,46 @@
+import sys
+from enum import Flag, auto
+
+COLOR_SUPPORT = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+class FMT(Flag):
+    RED = auto()
+    BLUE = auto()
+    YELLOW = auto()
+    GREEN = auto()
+    ORANGE = auto()
+    BOLD = auto()
+    GRAY = auto()
+    UNDERLINE = auto()
+    RESET = auto()
+
+    def __str__(self) -> str:
+        if not COLOR_SUPPORT:
+            return ""
+        fmt_str = []
+        for f in self:
+            match f:
+                case FMT.RED:
+                    fmt_str.append("\033[31m")
+                case FMT.ORANGE:
+                    fmt_str.append("\033[33m")
+                case FMT.GRAY:
+                    fmt_str.append("\033[37m")
+                case FMT.GREEN:
+                    fmt_str.append("\033[32m")
+                case FMT.BLUE:
+                    fmt_str.append("\033[34m")
+                case FMT.YELLOW:
+                    fmt_str.append("\033[93m")
+                case FMT.BOLD:
+                    fmt_str.append("\033[1m")
+                case FMT.RESET:
+                    fmt_str.append("\033[0m")
+                case FMT.UNDERLINE:
+                    fmt_str.append("\033[4m")
+        return "".join(fmt_str)
+
+
+WARN = FMT.ORANGE | FMT.UNDERLINE
+ERR = FMT.RED | FMT.BOLD

--- a/filecheck/colors.py
+++ b/filecheck/colors.py
@@ -19,28 +19,26 @@ class FMT(Flag):
         if not COLOR_SUPPORT:
             return ""
         fmt_str: list[str] = []
-        for f in self:
-            match f:
-                case FMT.RED:
-                    fmt_str.append("\033[31m")
-                case FMT.ORANGE:
-                    fmt_str.append("\033[33m")
-                case FMT.GRAY:
-                    fmt_str.append("\033[37m")
-                case FMT.GREEN:
-                    fmt_str.append("\033[32m")
-                case FMT.BLUE:
-                    fmt_str.append("\033[34m")
-                case FMT.YELLOW:
-                    fmt_str.append("\033[93m")
-                case FMT.BOLD:
-                    fmt_str.append("\033[1m")
-                case FMT.RESET:
-                    fmt_str.append("\033[0m")
-                case FMT.UNDERLINE:
-                    fmt_str.append("\033[4m")
-                case _:
-                    raise ValueError(f"Unknown color {f}")
+
+        if FMT.RED in self:
+            fmt_str.append("\033[31m")
+        if FMT.ORANGE in self:
+            fmt_str.append("\033[33m")
+        if FMT.GRAY in self:
+            fmt_str.append("\033[37m")
+        if FMT.GREEN in self:
+            fmt_str.append("\033[32m")
+        if FMT.BLUE in self:
+            fmt_str.append("\033[34m")
+        if FMT.YELLOW in self:
+            fmt_str.append("\033[93m")
+        if FMT.BOLD in self:
+            fmt_str.append("\033[1m")
+        if FMT.RESET in self:
+            fmt_str.append("\033[0m")
+        if FMT.UNDERLINE in self:
+            fmt_str.append("\033[4m")
+
         return "".join(fmt_str)
 
 

--- a/filecheck/colors.py
+++ b/filecheck/colors.py
@@ -18,7 +18,7 @@ class FMT(Flag):
     def __str__(self) -> str:
         if not COLOR_SUPPORT:
             return ""
-        fmt_str = []
+        fmt_str: list[str] = []
         for f in self:
             match f:
                 case FMT.RED:
@@ -39,6 +39,8 @@ class FMT(Flag):
                     fmt_str.append("\033[0m")
                 case FMT.UNDERLINE:
                     fmt_str.append("\033[4m")
+                case _:
+                    raise ValueError(f"Unknown color {f}")
         return "".join(fmt_str)
 
 

--- a/filecheck/finput.py
+++ b/filecheck/finput.py
@@ -190,7 +190,7 @@ class FInput:
             if match is not None:
                 return match
 
-    def print_line_with_current_pos(self, pos_override: int | None = None):
+    def print_line_with_current_pos(self, pos_override: int | None = None) -> str:
         """
         Print the current position in the input file.
         """
@@ -205,9 +205,11 @@ class FInput:
 
         last_newline_at = self.start_of_line(pos)
         char_pos = pos - last_newline_at
-        print(f"Matching at {fname}:{self.line_no}:{char_pos}")
-        print(self.content[last_newline_at + 1 : next_newline_at])
-        print(" " * (char_pos - 1), end="^\n")
+        return (
+            f"Matching at {fname}:{self.line_no}:{char_pos}\n"
+            f"{self.content[last_newline_at + 1 : next_newline_at]}\n"
+            + f"{'^':>{char_pos}}"
+        )
 
     def start_of_line(self, pos: int | None = None) -> int:
         """

--- a/filecheck/help.py
+++ b/filecheck/help.py
@@ -11,7 +11,7 @@ FLAGS:
                                   starting with $ are deleted after each CHECK-LABEL
                                   match.
 --match-full-lines              : Expect every check line to match the whole line.
-
+--reject-empty-vars             : Raise an error when a value captures an empty string.
 
 ARGUMENTS:
 check-file                      : The file from which the check lines are to be read

--- a/filecheck/logging.py
+++ b/filecheck/logging.py
@@ -1,0 +1,20 @@
+import sys
+
+from filecheck.colors import WARN, FMT
+from filecheck.ops import CheckOp
+from filecheck.options import Options
+
+
+def warn(
+    msg: str,
+    *,
+    op: CheckOp | None = None,
+    input_loc: str | None = None,
+    opts: Options,
+):
+    print(f"{WARN}Warning: {msg}{FMT.RESET}", end="", file=sys.stderr)
+    if input_loc:
+        print(f" at {input_loc}", end="", file=sys.stderr)
+    print("", file=sys.stderr)
+    if op:
+        print(op.source_repr(opts), file=sys.stderr)

--- a/filecheck/ops.py
+++ b/filecheck/ops.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Callable, TypeAlias
 
@@ -24,9 +25,11 @@ class CheckOp:
     def check_line_repr(self, prefix: str = "CHECK"):
         return f"{prefix}{self._suffix()}: {self.arg}"
 
-    def print_source_repr(self, opts: Options):
-        print(f"Check rule at {opts.match_filename}:{self.source_line}")
-        print(self.check_line_repr(opts.check_prefix))
+    def source_repr(self, opts: Options) -> str:
+        return (
+            f"Check rule at {opts.match_filename}:{self.source_line}\n"
+            f"{self.check_line_repr(opts.check_prefix)}"
+        )
 
     def _suffix(self):
         suffix = "{LITERAL}" if self.is_literal else ""

--- a/filecheck/options.py
+++ b/filecheck/options.py
@@ -19,6 +19,7 @@ class Options:
     allow_empty: bool = False
     comment_prefixes: list[str] = "COM,RUN"  # type: ignore[reportAssignmentType]
     variables: dict[str, str | int] = field(default_factory=dict)
+    reject_empty_vars: bool = False
 
     extensions: set[Extension] = field(default_factory=set)
 

--- a/filecheck/parser.py
+++ b/filecheck/parser.py
@@ -2,9 +2,9 @@
 parser for filecheck syntax
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import Iterator, TextIO
-import re
 
 from filecheck.error import ParseError
 from filecheck.ops import CheckOp, Literal, RE, Capture, Subst, NumSubst, UOp, CountOp
@@ -29,7 +29,7 @@ def pattern_for_opts(opts: Options) -> tuple[re.Pattern[str], re.Pattern[str]]:
 
 
 # see https://llvm.org/docs/CommandGuide/FileCheck.html#filecheck-string-substitution-blocks
-VAR_CAPTURE_PATTERN = re.compile(r"\[\[(\$?[a-zA-Z_][a-zA-Z0-9_]*):([^\n]+)]]")
+VAR_CAPTURE_PATTERN = re.compile(r"\[\[(\$?[a-zA-Z_][a-zA-Z0-9_]*):([^\n]*)]]")
 
 # see https://llvm.org/docs/CommandGuide/FileCheck.html#filecheck-string-substitution-blocks
 VAR_SUBST_PATTERN = re.compile(r"\[\[(\$?[a-zA-Z_][a-zA-Z0-9_]*)]]")
@@ -45,7 +45,6 @@ NUMERIC_CAPTURE_PATTERN = re.compile(
 NUMERIC_SUBST_PATTERN = re.compile(
     r"\[\[#(\$?[a-zA-Z_][a-zA-Z0-9_]*)([a-z0-9 +\-()]*)]]"
 )
-
 
 LINE_SPLIT_RE = split = re.compile(r"(\{\{|\[\[\$?[#a-zA-Z_]|]|})")
 

--- a/tests/filecheck/diagnostics/reject-empty-vars.test
+++ b/tests/filecheck/diagnostics/reject-empty-vars.test
@@ -1,0 +1,15 @@
+// RUN:  strip-comments.sh %s | exfail filecheck %s --reject-empty-vars | filecheck %s --check-prefix DIAG
+
+test 123
+// CHECK: test [[VAL:]]
+// CHECK-SAME: [[VAL]]
+
+// the warning printed:
+// DIAG:        Warning: Empty pattern capture
+// DIAG-NEXT:   Check rule at {{.*}}tests/filecheck/diagnostics/reject-empty-vars.test:4
+// DIAG-NEXT:   CHECK: test [[VAL:]]
+// the error printed:
+// DIAG-NEXT:   tests/filecheck/diagnostics/reject-empty-vars.test:4: error: Empty value captured for variable "VAL"
+// DIAG-NEXT:   Matching at <stdin>:1:6
+// DIAG-NEXT:   test 123
+// DIAG-NEXT: {{     }}^

--- a/tests/filecheck/variables.test
+++ b/tests/filecheck/variables.test
@@ -49,3 +49,9 @@ test %arg1
 // CHECK:       test [[ARG:%[[:alnum:]]+]]
 test [%arg1][0]
 // CHECK-NEXT:  test [[[ARG]]][0]
+
+
+// we have to replicate FileChecks behaviour here, and allow empty varaible captures:
+test 123
+// CHECK: test [[VAL:]]
+// CHECK-SAME: [[VAL]]


### PR DESCRIPTION
This patch adds:
- color to printed messages
- prints messages to stderr
- allow empty value captures (fixes #5)
- adds a new flag `--reject-empty-vars` that throws errors when zero characters are captured