### PR TITLE
Add support for --check-prefixes (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # filecheck - A Python-native clone of LLVMs FileCheck tool
 
-This tries to be as close a clone of LLVMs FileCheck as possible, without going crazy. It currently passes 1555 out of
-1645 (94.5%) of LLVMs MLIR filecheck tests.
+This tries to be as close a clone of LLVMs FileCheck as possible, without going crazy. It currently passes 1576 out of
+1645 (95.8%) of LLVMs MLIR filecheck tests.
 
 There are some features that are left out for now (e.g.a
 [pseudo-numeric variables](https://llvm.org/docs/CommandGuide/FileCheck.html#filecheck-pseudo-numeric-variables) and
@@ -25,7 +25,7 @@ Here's an overview of all FileCheck features and their implementation status.
   - [X] `CHECK-COUNT`
 - **Flags:**
   - [X] `--check-prefix`
-  - [ ] `--check-prefixes` (Tracking: [#13](https://github.com/AntonLydike/filecheck/issues/13))
+  - [X] `--check-prefixes`
   - [X] `--comment-prefixes`
   - [ ] `--allow-unused-prefixes`
   - [X] `--input-file`

--- a/filecheck/ops.py
+++ b/filecheck/ops.py
@@ -16,26 +16,31 @@ class CheckOp:
     Represents a concrete check instruction (e.g. CHECK-NEXT)
     """
 
+    prefix: str
     name: str
     arg: str
     source_line: int
     uops: list[UOp]
     is_literal: bool = field(default=False, kw_only=True)
 
-    def check_line_repr(self, prefix: str = "CHECK"):
-        return f"{prefix}{self._suffix()}: {self.arg}"
+    def check_line_repr(self):
+        return f"{self.check_name}: {self.arg}"
 
     def source_repr(self, opts: Options) -> str:
         return (
             f"Check rule at {opts.match_filename}:{self.source_line}\n"
-            f"{self.check_line_repr(opts.check_prefix)}"
+            f"{self.check_line_repr()}"
         )
 
     def _suffix(self):
         suffix = "{LITERAL}" if self.is_literal else ""
         if self.name == "CHECK":
             return suffix
-        return "-" + self.name + suffix
+        return f"-{self.name}{suffix}"
+
+    @property
+    def check_name(self):
+        return f"{self.prefix}{self._suffix()}"
 
 
 @dataclass(slots=True)
@@ -48,7 +53,7 @@ class CountOp(CheckOp):
 
     def _suffix(self):
         suffix = "{LITERAL}" if self.is_literal else ""
-        return f"-COUNT{self.count}" + suffix
+        return f"-COUNT{self.count}{suffix}"
 
 
 @dataclass(frozen=True, slots=True)

--- a/filecheck/options.py
+++ b/filecheck/options.py
@@ -98,15 +98,20 @@ def parse_argv_options(argv: list[str]) -> Options:
                 raise RuntimeError("Out of range arguments")
             # make sure to append check and comment prefixes if flag is used multiple times
             if arg in ("check_prefix", "comment_prefixes") and arg in opts:
-                opts[arg] += "," + argv[i + 1]
+                existing_opts = opts[arg]
+                assert isinstance(existing_opts, str)
+                existing_opts += "," + argv[i + 1]
             else:
                 opts[arg] = argv[i + 1]
             remove.add(i + 1)
 
     if "check_prefix" in opts:
         prefixes = opts.pop("check_prefix")
+        assert isinstance(prefixes, str)
         if "check_prefixes" in opts:
-            prefixes += "," + opts.pop("check_prefixes")
+            more_prefixes = opts.pop("check_prefixes")
+            assert isinstance(more_prefixes, str)
+            prefixes += "," + more_prefixes
         opts["check_prefixes"] = prefixes
 
     for idx in sorted(remove, reverse=True):

--- a/filecheck/preprocess.py
+++ b/filecheck/preprocess.py
@@ -29,9 +29,7 @@ class Preprocessor:
         pattern, _ = compile_uops(op, dict(), self.opts)
         match = self.input.find_between(pattern, self.range)
         if not match:
-            raise CheckError(
-                f"{self.opts.check_prefix}-LABEL: Could not find label in input", op
-            )
+            raise CheckError(f"{op.check_name}: Could not find label in input", op)
 
         self.range = self.range.split_at(match)
         self.input.ranges.append(self.range)

--- a/tests/filecheck/flags/check-prefixes.test
+++ b/tests/filecheck/flags/check-prefixes.test
@@ -1,0 +1,12 @@
+// RUN: strip-comments.sh %s | filecheck --check-prefixes=CHECK,CHECK2 %s
+// RUN: strip-comments.sh %s | filecheck --check-prefix CHECK --check-prefix CHECK2 %s
+// RUN: strip-comments.sh %s | filecheck --check-prefixes=CHECK --check-prefix CHECK2 %s
+
+test 123
+// CHECK: test
+// CHECK2-SAME: 123
+test 456
+// CHECK: test
+// CHECK2-SAME: 456
+// CHECK-NOT: bad
+// CHECK2-NOT: bad2


### PR DESCRIPTION
This patch:
- moves the check prefix onto the `CheckOp` dataclass
- adds support for specifying `--check-prefix` multiple times in the command line args
- moves the `Options.check_prefix` flag to `Options.check_prefixes` and changes type to `list[str]`
- Adds support in the parser for parsing with multiple prefixes