### PR TITLE
checks: Make check-empty also work on EOF (fixes #23)

### DIFF
--- a/filecheck/finput.py
+++ b/filecheck/finput.py
@@ -12,6 +12,8 @@ from typing import Iterable
 
 from filecheck.options import Options
 
+ANY_NEWLINES = re.compile(r"\n*")
+
 
 @dataclass(slots=True)
 class InputRange:
@@ -259,6 +261,12 @@ class FInput:
         if self.range.start == len(self.content) - 1:
             return True
         return False
+
+    def is_end_of_file(self) -> bool:
+        """
+        Check if only whitespace characters are left in the file
+        """
+        return ANY_NEWLINES.fullmatch(self.content, self.range.start) is not None
 
     def starts_with(self, expr: str) -> bool:
         return self.content.startswith(expr, self.range.start)

--- a/filecheck/matcher.py
+++ b/filecheck/matcher.py
@@ -250,7 +250,7 @@ class Matcher:
         # check immediately
         if not self.opts.match_full_lines:
             self.file.skip_to_end_of_line()
-        if not self.file.starts_with("\n\n"):
+        if not (self.file.starts_with("\n\n") or self.file.is_end_of_file()):
             raise CheckError(
                 f"{op.check_name}: is not on the line after the previous match",
                 op,

--- a/tests/filecheck/checks/check-empty-eof.test
+++ b/tests/filecheck/checks/check-empty-eof.test
@@ -1,0 +1,5 @@
+// RUN: strip-comments.sh %s | filecheck %s
+test
+// CHECK: test
+// verify that CHECK-EMPTY can be used to check that nothing is left in the current range (i.e. before the next label)
+// CHECK-EMPTY:


### PR DESCRIPTION
This makes `CHECK-EMPTY` succeed if EOF was reached. Closes #23 