### PR TITLE
Stricter prefix matching (fixes #28)

### DIFF
--- a/filecheck/finput.py
+++ b/filecheck/finput.py
@@ -10,6 +10,7 @@ import sys
 from dataclasses import dataclass, field
 from typing import Iterable
 
+from filecheck.colors import FMT
 from filecheck.options import Options
 
 
@@ -288,6 +289,14 @@ class FInput:
         if match is not None:
             self.range.add_hole(InputRange(match.start(0), match.end(0)))
         return match
+
+    def print_current_range(self):
+        end = self.range.start
+        for a, b in self.range.ranges():
+            yield f"{FMT.GRAY}{self.content[end:a]}{FMT.RESET}"
+            yield f"{self.content[a:b]}"
+            end = b
+        yield f"{FMT.GRAY}{self.content[end:self.range.end]}{FMT.RESET}"
 
     def advance_to_last_hole(self):
         """

--- a/filecheck/matcher.py
+++ b/filecheck/matcher.py
@@ -126,6 +126,10 @@ class Matcher:
             )
             print("Current position at " + self.file.print_line(), file=sys.stderr)
 
+            if self.file.is_discontigous():
+                print("\nCurrently matching in:", file=sys.stderr)
+                print("".join(self.file.print_current_range()), file=sys.stderr)
+
             # try to look for a shorter match, and print that if possible
             prefix_match = self.find_prefix_match_for(ex.op)
             if prefix_match is not None:
@@ -143,6 +147,9 @@ class Matcher:
                 self.file.print_line(ex.match.start(0), ex.match.end(0)),
                 file=sys.stderr,
             )
+            if self.file.is_discontigous():
+                print("\nCurrently matching in:", file=sys.stderr)
+                print("".join(self.file.print_current_range()), file=sys.stderr)
             return 1
 
         return 0

--- a/filecheck/matcher.py
+++ b/filecheck/matcher.py
@@ -127,7 +127,10 @@ class Matcher:
             print("Current position at " + self.file.print_line(), file=sys.stderr)
 
             if self.file.is_discontigous():
-                print("\nCurrently matching in:", file=sys.stderr)
+                print(
+                    "\nCurrently matching in range (grey is already matched):",
+                    file=sys.stderr,
+                )
                 print("".join(self.file.print_current_range()), file=sys.stderr)
 
             # try to look for a shorter match, and print that if possible
@@ -148,7 +151,10 @@ class Matcher:
                 file=sys.stderr,
             )
             if self.file.is_discontigous():
-                print("\nCurrently matching in:", file=sys.stderr)
+                print(
+                    "\nCurrently matching in range (grey is already matched):",
+                    file=sys.stderr,
+                )
                 print("".join(self.file.print_current_range()), file=sys.stderr)
             return 1
 

--- a/filecheck/parser.py
+++ b/filecheck/parser.py
@@ -19,7 +19,8 @@ from filecheck.regex import (
 def pattern_for_opts(opts: Options) -> tuple[re.Pattern[str], re.Pattern[str]]:
     prefixes = f"({'|'.join(map(re.escape, opts.check_prefixes))})"
     return re.compile(
-        prefixes
+        r"(^|[^a-zA-Z])"
+        + prefixes
         + r"(-(DAG|COUNT-\d+|NOT|EMPTY|NEXT|SAME|LABEL))?(\{LITERAL})?:\s?([^\n]*)\n?"
     ), re.compile(f"({'|'.join(map(re.escape, opts.comment_prefixes))}).*{prefixes}")
 
@@ -86,10 +87,10 @@ class Parser(Iterator[CheckOp]):
             # no check line = skip
             if match is None:
                 continue
-            prefix = match.group(1)
-            kind = match.group(3)
-            literal = match.group(4)
-            arg = match.group(5)
+            prefix = match.group(2)
+            kind = match.group(4)
+            literal = match.group(5)
+            arg = match.group(6)
             if kind is None:
                 kind = "CHECK"
             if arg is None:

--- a/tests/filecheck/flags/check-prefix.test
+++ b/tests/filecheck/flags/check-prefix.test
@@ -3,3 +3,4 @@
 
 hallo welt
 // TEST: hallo welt
+// NOTEST: will not be matched


### PR DESCRIPTION
This PR adds the requirement that the `CHECK` be preceded by either a new-line, or a character that is not `[A-Za-z]`. This fixes #28 

It also adds diagnostic printing when checking fails inside a DAG region by printing all currently considered input and greying out regions that are already consumed.