### PR TITLE
Fix issue with windows newlines not being normalised (fixes #27)

### DIFF
--- a/filecheck/finput.py
+++ b/filecheck/finput.py
@@ -126,6 +126,10 @@ class FInput:
     ranges: list[InputRange] = field(default_factory=list)
 
     @staticmethod
+    def canonicalize_line_ends(text: str) -> str:
+        return text.replace("\r\n", "\n")
+
+    @staticmethod
     def from_opts(opts: Options) -> FInput:
         """
         Create a FInput object from options objects
@@ -135,7 +139,7 @@ class FInput:
             f = sys.stdin
         else:
             f = open(opts.input_file, "r")
-        return FInput(opts.input_file, f.read())
+        return FInput(opts.input_file, FInput.canonicalize_line_ends(f.read()))
 
     def advance_by(self, dist: int):
         """

--- a/filecheck/parser.py
+++ b/filecheck/parser.py
@@ -19,7 +19,7 @@ from filecheck.regex import (
 def pattern_for_opts(opts: Options) -> tuple[re.Pattern[str], re.Pattern[str]]:
     prefixes = f"({'|'.join(map(re.escape, opts.check_prefixes))})"
     return re.compile(
-        r"(^|[^a-zA-Z])"
+        r"(^|[^a-zA-Z-_])"
         + prefixes
         + r"(-(DAG|COUNT-\d+|NOT|EMPTY|NEXT|SAME|LABEL))?(\{LITERAL})?:\s?([^\n]*)\n?"
     ), re.compile(f"({'|'.join(map(re.escape, opts.comment_prefixes))}).*{prefixes}")

--- a/tests/filecheck/windows_line_endings.test
+++ b/tests/filecheck/windows_line_endings.test
@@ -1,0 +1,5 @@
+// RUN: echo -e "1\r\n2\r\n\r\n3" | filecheck %s
+CHECK: 1
+CHECK-NEXT: 2
+CHECK-EMPTY:
+CHECK-NEXT: 3


### PR DESCRIPTION
This PR fixes #27 

It also contains a small additonal fix for #29, where `_` and `-` are also not allowed before a check prefix.