### PR TITLE
Implement performance optimisation for string literal matching

### DIFF
--- a/filecheck/finput.py
+++ b/filecheck/finput.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import Iterable
 
 from filecheck.colors import FMT
+from filecheck.compiler import PatternT, MatchT
 from filecheck.options import Options
 
 ANY_NEWLINES = re.compile(r"\n*")
@@ -27,7 +28,7 @@ class InputRange:
     def restrict_end(self, new_end: int):
         return InputRange(self.start, new_end)
 
-    def split_at(self, match: re.Match[str]):
+    def split_at(self, match: MatchT):
         """
         Split this range at match by truncating the end of this range to the start of
         the match, and returning a new range starting at the end of the match, until
@@ -155,7 +156,7 @@ class FInput:
         """
         self.advance_by(new_pos - self.range.start)
 
-    def match(self, pattern: re.Pattern[str]) -> re.Match[str] | None:
+    def match(self, pattern: PatternT) -> MatchT | None:
         """
         Match (exactly from the current position)
         """
@@ -163,9 +164,9 @@ class FInput:
 
     def find(
         self,
-        pattern: re.Pattern[str],
+        pattern: PatternT,
         this_line: bool = False,
-    ) -> re.Match[str] | None:
+    ) -> MatchT | None:
         """
         Find the first occurance of a pattern, might be far away.
 
@@ -183,9 +184,7 @@ class FInput:
 
         return pattern.search(self.content, pos=irange.start, endpos=irange.end)
 
-    def find_between(
-        self, pattern: re.Pattern[str], irange: InputRange
-    ) -> re.Match[str] | None:
+    def find_between(self, pattern: PatternT, irange: InputRange) -> MatchT | None:
         """
         Find the first occurance of a pattern, might be far away.
         """
@@ -284,7 +283,7 @@ class FInput:
         assert not isinstance(self.range, DiscontigousRange)
         self.range = DiscontigousRange(self.range.start, self.range.end)
 
-    def match_and_add_hole(self, pattern: re.Pattern[str]) -> re.Match[str] | None:
+    def match_and_add_hole(self, pattern: PatternT) -> MatchT | None:
         """
         Find the first occurance of a pattern in a discontigous range.
 

--- a/filecheck/ops.py
+++ b/filecheck/ops.py
@@ -62,7 +62,8 @@ class UOp:
     micro-ops, thse make up the filecheck matching logic
     """
 
-    pass
+    def get_literal(self, vars: dict[str, str | int]) -> str:
+        raise NotImplementedError()
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,6 +73,9 @@ class Literal(UOp):
     """
 
     content: str
+
+    def get_literal(self, vars: dict[str, str | int]) -> str:
+        return self.content
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,6 +119,9 @@ class Subst(UOp):
     """
 
     variable: str
+
+    def get_literal(self, vars: dict[str, str | int]) -> str:
+        return str(vars.get(self.variable))
 
 
 @dataclass(frozen=True, slots=True)

--- a/filecheck/regex.py
+++ b/filecheck/regex.py
@@ -1,4 +1,6 @@
 import re
+import sys
+from dataclasses import dataclass
 from typing import Callable
 
 POSIX_REGEXP_PATTERN = re.compile(
@@ -80,3 +82,120 @@ def pattern_from_num_subst_spec(
 
 def hex_int(v: str):
     return int(v, base=16)
+
+
+class LiteralMatch:
+    """
+    Replaces re.Match class for literal matches
+    """
+
+    _start: int
+    _end: int
+    _content: str
+
+    def __init__(self, start: int, content: str):
+        self._start = start
+        self._end = start + len(content)
+        self._content = content
+
+    def start(self, group: int = 0):
+        assert group == 0
+        return self._start
+
+    def end(self, group: int = 0):
+        assert group == 0
+        return self._end
+
+    def group(self, group: int):
+        assert group == 0
+        return self._content
+
+
+@dataclass
+class LiteralMatcher:
+    """
+    Class meant to emulate re.Pattern class for strictly literal patterns
+    """
+
+    pattern: str
+    strict_whitespace: bool
+    match_on_next_line: bool
+
+    def search(
+        self, string: str, pos: int = 0, endpos: int = sys.maxsize
+    ) -> LiteralMatch | None:
+        """
+        Scan through string looking for the first location where this regular expression produces a match, and return a
+        corresponding Match. Return None if no position in the string matches the pattern; note that this is different
+        from finding a zero-length match at some point in the string.
+        """
+        start = string.find(self.pattern, pos, endpos)
+        if start != -1:
+            return LiteralMatch(start, self.pattern)
+
+        if self.strict_whitespace:
+            return None
+
+        # match whitespace insensitive
+        parts = re.split(r"\s+", self.pattern)
+
+        while pos < endpos:
+            candidate_start = string.find(parts[0], pos, endpos)
+            if candidate_start == -1:
+                return None
+            match_pos = candidate_start + len(parts[0])
+            did_match = False
+            for part in parts[1:]:
+                # eat space
+                while string[match_pos].isspace():
+                    match_pos += 1
+                if string.startswith(part, match_pos, endpos):
+                    match_pos += len(part)
+                else:
+                    break
+            else:
+                # set did_match to true, if loop didn't break
+                did_match = True
+            if did_match:
+                return LiteralMatch(candidate_start, string[candidate_start:match_pos])
+            pos = candidate_start + 1
+
+    def match(
+        self, string: str, pos: int = 0, endpos: int = sys.maxsize
+    ) -> LiteralMatch | None:
+        """
+        If zero or more characters at the beginning of string match this regular expression, return a corresponding
+        Match. Return None if the string does not match the pattern; note that this is different from a zero-length
+        match.
+        """
+        if self.match_on_next_line:
+            if string[pos] == "\n":
+                pos += 1
+            new_endpos = string.find("\n", pos, endpos)
+            if new_endpos == -1:
+                new_endpos = endpos
+            return self.search(string, pos, new_endpos)
+
+        if string.startswith(self.pattern, pos, endpos):
+            return LiteralMatch(pos, self.pattern)
+
+        if self.strict_whitespace:
+            return None
+
+        # match space insensitive
+        match_pos = pos
+        parts = re.split(r"\s+", self.pattern)
+        # for each part but not the last one, check the part and eat whitespace
+        for part in parts[:-1]:
+            # check that we start with the part
+            if not string.startswith(part, match_pos, endpos):
+                return None
+            match_pos += len(part)
+            # then eat space
+            while string[match_pos].isspace():
+                match_pos += 1
+        # check last part of pattern
+        if not string.startswith(parts[-1], match_pos, endpos):
+            return None
+        match_pos += len(parts[-1])
+        return LiteralMatch(pos, string[pos:match_pos])


### PR DESCRIPTION
This PR adds a performance optimisation that skips compiling a regex for string literal matching.

**Motivation:**

Issue #25 points out, that we are about ~6x slower than `filecheck 0.24` in the worst case, and about 3.3x on average.

We are also about 34x slower than LLVMs filecheck, but we can't get that down too far, due to pythons limitations. FileCheck is usually done before CPython finished loading the runtime.

**Approach:**

After some digging in traces (thanks to [viztracer](https://github.com/gaogaotiantian/viztracer)), I found that we spend a lot of time compiling regexes, even when they are just for fancy string literals (most of them are of the form `test\s+string\s...`, which is regular enough to special case. This time is dominating everything else by a huge margin:

![image](https://github.com/user-attachments/assets/7fec63b0-d6df-443b-9dff-95bceaf0790b)

The regex compile is about 135us of 156us total time spent, so about 85%. We then spend ~.8us on average in the actual matching logic. I was wondering how "slow" a non-regex implementation would compare.

I added logic in the existing check compiler that detects if the check is only made up of string literals, and returns a new `LiteralMatcher` that duck types `re.Pattern` for all cases that mater for our implementation. As it turns out that is just `find` and `match`.

Sadly we can't just replace `re.search` by `string.find` in all cases, as we need to handle white-space normalisation, which bloats the below code a bit. Otherwise it's quite readable though.

`LiteralMatcher` returns a special duck-typed version of `re.Match` called `LiteralMatch` that only has a single group. This is all that's needed for this little hack, and the other code can be left unmodified, thanks to the power of duck typing (and modifying some type hints).

**Results:**

The optimisation gets an average speedup in our benchmarks of 1.6x, making the new implementation only about 2.1x slower on average. This understates the effect though, as this optimisation manages to really cut down the longest benchmark (4.7k lines of `CHECK-NEXT` statements) times by more than 3x.

See the below chart for overall results:

![image](https://github.com/user-attachments/assets/b3069834-b46c-405f-a78a-b945a20618c6)

The new trace shows us that we have indeed removed a bottleneck:

![image](https://github.com/user-attachments/assets/41dba3d8-88c5-4b44-859e-bf924798fe1b)

The new timing shows that compilation time is down to 5.5us on average, but the matching has grown to ~14.7us on average. Still the average `CHECK-DAG` statement now is down to 21.6us, so a reduction of 7x.
