### PR TITLE
Add support for --dump-input flag (fixes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here's an overview of all FileCheck features and their implementation status.
   - [X] `--strict-whitespace` (Bug: [#6](https://github.com/AntonLydike/filecheck/issues/6))
   - [ ] `--ignore-case`
   - [ ] `--implicit-check-not` (Tracked: [#20](https://github.com/AntonLydike/filecheck/issues/20))
-  - [ ] `--dump-input` (Tracked: [#19](https://github.com/AntonLydike/filecheck/issues/19))
+  - [X] `--dump-input` (only `fail` and `never` supported)
   - [ ] `--dump-input-context`
   - [ ] `--dump-input-filter`
   - [X] `--enable-var-scope`

--- a/filecheck/help.py
+++ b/filecheck/help.py
@@ -12,7 +12,7 @@ FLAGS:
                                   match.
 --match-full-lines              : Expect every check line to match the whole line.
 --reject-empty-vars             : Raise an error when a value captures an empty string.
---dump-intput                   : Dump the input to stderr annotated with helpful
+--dump-input                    : Dump the input to stderr annotated with helpful
                                   information depending on the context. Allowed values
                                   are help, always, never, fail. Default is fail.
                                   Only fail and never is currently supported in this

--- a/filecheck/help.py
+++ b/filecheck/help.py
@@ -12,6 +12,11 @@ FLAGS:
                                   match.
 --match-full-lines              : Expect every check line to match the whole line.
 --reject-empty-vars             : Raise an error when a value captures an empty string.
+--dump-intput                   : Dump the input to stderr annotated with helpful
+                                  information depending on the context. Allowed values
+                                  are help, always, never, fail. Default is fail.
+                                  Only fail and never is currently supported in this
+                                  version of filecheck.
 
 ARGUMENTS:
 check-file                      : The file from which the check lines are to be read

--- a/tests/filecheck/flags/dump-input.test
+++ b/tests/filecheck/flags/dump-input.test
@@ -1,0 +1,12 @@
+// RUN: strip-comments.sh %s | filecheck %s --dump-input never --check-prefix RIGHT | filecheck %s --allow-empty --check-prefix EMPTY
+// RUN: strip-comments.sh %s | exfail filecheck %s --dump-input never --check-prefix WRONG | filecheck %s --allow-empty --check-prefix EMPTY
+// RUN: strip-comments.sh %s | filecheck %s --dump-input fail --check-prefix RIGHT | filecheck %s --allow-empty --check-prefix EMPTY
+// RUN: strip-comments.sh %s | exfail filecheck %s --dump-input fail --check-prefix WRONG | filecheck %s --allow-empty --check-prefix HAS-OUTPUT
+// RUN: strip-comments.sh %s | filecheck %s --dump-input help --check-prefix RIGHT 2>&1 | filecheck %s --allow-empty --check-prefix UNKNOWN-FLAG -DFLAG=help
+// RUN: strip-comments.sh %s | filecheck %s --dump-input always --check-prefix RIGHT 2>&1 | filecheck %s --allow-empty --check-prefix UNKNOWN-FLAG -DFLAG=always
+test
+// RIGHT: test
+// WRONG: wrong
+// EMPTY-NOT: {{.+}}
+// HAS-OUTPUT: error: Couldn't match "wrong".
+// UNKNOWN-FLAG: Warning: Unsupported dump-input flag: [[FLAG]]


### PR DESCRIPTION
This adds support for the `--dump-input` flag, but currently only supports two out of the four values implemented upstream:

- :green_circle: `never`: Don't print anything
- :green_circle: `fail`: Print diagnostics on failure
- :red_circle: `always`: Always print something
- :red_circle: `help`: Print help text fur `--dump-input`