### PR TITLE
Fix non-strict whitespace matching newlines (fixes #37)

### DIFF
--- a/filecheck/compiler.py
+++ b/filecheck/compiler.py
@@ -39,7 +39,9 @@ def compile_uops(
                 # but I still want to regex escape them
                 # and re.sub doesn't let me insert \s into the new string for some reason......
                 expr.append(
-                    re.sub(r"(\\ )+", " ", re.escape(uop.content)).replace(" ", r"\s+")
+                    re.sub(r"(\\ )+", " ", re.escape(uop.content)).replace(
+                        " ", r"[ \t\v]+"
+                    ),
                 )
 
         elif isinstance(uop, RE):

--- a/tests/filecheck/issue-37.test
+++ b/tests/filecheck/issue-37.test
@@ -1,0 +1,9 @@
+// RUN: strip-comments.sh %s | filecheck %s
+
+ax
+x, x,
+x,
+
+// CHECK: ax
+// CHECK-NEXT: x, x,
+// CHECK: x,

--- a/tests/filecheck/regex.test
+++ b/tests/filecheck/regex.test
@@ -15,7 +15,7 @@ test 123, 123
 test a b
 // CHECK: test {{a|b}} {{b|c}}
 
-test something
+test something 
 // CHECK: test something {{$}}
 
 test another thing


### PR DESCRIPTION
This fixes a bug where `x x` would be translated to `x\s+x`, which is subtly wrong as `\s` allows newline matching. The more correct way is `x[ \t\v]+x`, which it now is with this patch.

Fixes #37 