### PR TITLE
Fix broken match-full-lines flag (fixes #40)

### DIFF
--- a/filecheck/matcher.py
+++ b/filecheck/matcher.py
@@ -210,7 +210,7 @@ class Matcher:
                 # reset the state
                 self.ctx.negative_matches_start = None
                 self.ctx.negative_matches_stack = []
-        elif self.opts.match_full_lines:
+        if self.opts.match_full_lines:
             if not self.file.is_end_of_line():
                 raise CheckError(
                     "Didn't match whole line",

--- a/tests/filecheck/flags/match-full-lines2.test
+++ b/tests/filecheck/flags/match-full-lines2.test
@@ -1,0 +1,6 @@
+// RUN: strip-comments.sh %s | exfail filecheck --match-full-lines %s | filecheck --check-prefix DIAG %s
+
+abc
+// CHECK: b
+// DIAG: match-full-lines2.test:4
+// DIAG: error: Didn't match whole line


### PR DESCRIPTION
As pointed out by @ythri in #40, the `--match-full-lines` flag was not being honoured properly, this is fixed with this PR!