### PR TITLE
Skip partially matching lines in --match-full-lines mode (fixes #47)

### DIFF
--- a/filecheck/compiler.py
+++ b/filecheck/compiler.py
@@ -91,18 +91,18 @@ def compile_uops(
         elif isinstance(uop, NumSubst):
             # we don't do numerical substitutions yet
             raise NotImplementedError("Numerical substitutions not supported!")
+    pattern = "".join(expr)
+    if opts.match_full_lines:
+        # require the check to match a whole line: the pattern must start at the
+        # beginning of a line and end at the end of a line. Partial matches on
+        # other lines are then simply skipped instead of being an error (fixes #47).
+        # (non-capturing lookaround, so capture group numbering is unaffected)
+        pattern = f"(?:(?<=\\n)|(?=\\A)){pattern}(?=\\n|\\Z)"
+    if check.name == "NEXT":
+        # the prefix is added after the full-line anchors, so that the anchors
+        # apply to the check itself and not to the skipped leading characters
+        pattern = r"\n?[^\n]*" + pattern
     try:
-        pattern = "".join(expr)
-        if opts.match_full_lines:
-            # require the check to match a whole line: the pattern must start at the
-            # beginning of a line and end at the end of a line. Partial matches on
-            # other lines are then simply skipped instead of being an error (fixes #47).
-            # (non-capturing lookaround, so capture group numbering is unaffected)
-            pattern = f"(?:(?<=\\n)|(?=\\A)){pattern}(?=\\n|\\Z)"
-        if check.name == "NEXT":
-            # the prefix is added after the full-line anchors, so that the anchors
-            # apply to the check itself and not to the skipped leading characters
-            pattern = r"\n?[^\n]*" + pattern
         # compile with MULTILINE flag, so that `^` and `$` can match start/end of line correctly
         return re.compile(pattern, flags=re.MULTILINE), captures
     except re.error:

--- a/filecheck/compiler.py
+++ b/filecheck/compiler.py
@@ -30,9 +30,7 @@ def compile_uops(
     """
     groups = 0
     expr: list[str] = []
-    if check.name == "NEXT":
-        expr.append(r"\n?[^\n]*")
-    elif check.name == "EMPTY":
+    if check.name == "EMPTY":
         return CHECK_EMPTY_EXPR, dict()
 
     captures: dict[str, tuple[int, VALUE_MAPPER_T]] = dict()
@@ -94,7 +92,18 @@ def compile_uops(
             # we don't do numerical substitutions yet
             raise NotImplementedError("Numerical substitutions not supported!")
     try:
+        pattern = "".join(expr)
+        if opts.match_full_lines:
+            # require the check to match a whole line: the pattern must start at the
+            # beginning of a line and end at the end of a line. Partial matches on
+            # other lines are then simply skipped instead of being an error (fixes #47).
+            # (non-capturing lookaround, so capture group numbering is unaffected)
+            pattern = f"(?:(?<=\\n)|(?=\\A)){pattern}(?=\\n|\\Z)"
+        if check.name == "NEXT":
+            # the prefix is added after the full-line anchors, so that the anchors
+            # apply to the check itself and not to the skipped leading characters
+            pattern = r"\n?[^\n]*" + pattern
         # compile with MULTILINE flag, so that `^` and `$` can match start/end of line correctly
-        return re.compile("".join(expr), flags=re.MULTILINE), captures
+        return re.compile(pattern, flags=re.MULTILINE), captures
     except re.error:
-        raise CheckError(f"Malformed regex expression: '{''.join(expr)}'", check)
+        raise CheckError(f"Malformed regex expression: '{pattern}'", check)

--- a/filecheck/finput.py
+++ b/filecheck/finput.py
@@ -262,8 +262,8 @@ class FInput:
         # line ending check
         if self.content.startswith("\n", self.range.start):
             return True
-        # eof check
-        if self.range.start == len(self.content) - 1:
+        # eof check (covers a final line without a trailing newline)
+        if self.range.start >= len(self.content) - 1:
             return True
         return False
 

--- a/filecheck/matcher.py
+++ b/filecheck/matcher.py
@@ -210,7 +210,11 @@ class Matcher:
                 # reset the state
                 self.ctx.negative_matches_start = None
                 self.ctx.negative_matches_stack = []
-        if self.opts.match_full_lines:
+        if self.opts.match_full_lines and op.name != "DAG":
+            # DAG ops don't advance the file position to the end of the match
+            # (they record holes instead), so the position check doesn't apply.
+            # For all other ops the pattern is anchored to full lines by the
+            # compiler, so this should never trigger.
             if not self.file.is_end_of_line():
                 raise CheckError(
                     "Didn't match whole line",

--- a/tests/filecheck/flags/match-full-lines2.test
+++ b/tests/filecheck/flags/match-full-lines2.test
@@ -3,4 +3,4 @@
 abc
 // CHECK: b
 // DIAG: match-full-lines2.test:4
-// DIAG: error: Didn't match whole line
+// DIAG: error: Couldn't match "b"

--- a/tests/filecheck/flags/match-full-lines3.test
+++ b/tests/filecheck/flags/match-full-lines3.test
@@ -1,0 +1,11 @@
+// partially matching lines must be skipped, not an error (issue #47)
+// RUN: strip-comments.sh %s | filecheck --match-full-lines %s
+
+abcd
+0123
+// CHECK: 12
+12
+// CHECK-DAG: x
+x
+// CHECK-DAG: y
+y


### PR DESCRIPTION
Instead of raising 'Didn't match whole line' when a check matched part of a line, anchor the compiled pattern to full lines when --match-full-lines is set: a check now only matches if it spans an entire line, so partially matching lines are simply skipped and the search continues.

- compiler: wrap the check pattern in non-capturing line lookarounds `((?:(?<=\n)|(?=\A))pattern(?=\n|\Z))` when match_full_lines is set; the CHECK-NEXT prefix is added afterwards so the anchors apply to the check itself. No capturing groups are added, so capture numbering is unaffected.
- finput.is_end_of_line: treat a position at EOF as end-of-line, fixing a spurious error when the last line matches but has no trailing newline.
- matcher: skip the post-match full-line position check for CHECK-DAG, whose file position does not advance to the end of the match (holes are tracked instead); the anchored pattern already guarantees full lines.
- tests: the exfail test now expects the proper 'Couldn't match' error, and a new test covers the issue #47 scenario (skip partial line, match a later one) including CHECK-DAG in full-line mode.

This PR was authored by Qwen 3.8 27B, but reviewed by human.