### PR TITLE
Reject whitespace-only checks in non-strict mode

### DIFF
--- a/filecheck/parser.py
+++ b/filecheck/parser.py
@@ -109,17 +109,21 @@ class Parser(Iterator[CheckOp]):
                 kind = "CHECK"
             if arg is None:
                 arg = ""
+            if not self.opts.strict_whitespace:
+                arg = arg.strip()
+
             # verify that non-empty checks have an actual thing to match
             if kind != "EMPTY":
                 if not arg:
+                    offset = (
+                        match.start(4) if match.group(4) is not None else match.start(2)
+                    )
                     raise ParseError(
-                        f"found empty check string with prefix '{kind}:'",
+                        f"found empty check string with prefix '{prefix}:'",
                         self.line_no,
-                        match.start(4),
+                        offset,
                         line,
                     )
-            if not self.opts.strict_whitespace:
-                arg = arg.strip()
 
             # parse the uops, but only if we are not in LITERAL mode
             uops: list[UOp]

--- a/tests/filecheck/diagnostics/empty-check-plain.test
+++ b/tests/filecheck/diagnostics/empty-check-plain.test
@@ -1,0 +1,10 @@
+// RUN: strip-comments.sh %s | exfail filecheck %s --comment-prefixes=RUN,COM,DIAG | filecheck %s --check-prefix=DIAG
+
+foo
+bar
+
+// CHECK: foo
+// CHECK:   
+// CHECK: bar
+
+// DIAG: found empty check string with prefix 'CHECK:'

--- a/tests/filecheck/diagnostics/empty-check.test
+++ b/tests/filecheck/diagnostics/empty-check.test
@@ -1,0 +1,10 @@
+// RUN: strip-comments.sh %s | exfail filecheck %s --comment-prefixes=RUN,COM,DIAG | filecheck %s --check-prefix=DIAG
+
+foo
+bar
+
+// CHECK: foo
+// CHECK-NEXT:   
+// CHECK: bar
+
+// DIAG: found empty check string with prefix 'CHECK:'


### PR DESCRIPTION
When a non-EMPTY check directive contained only whitespace after the
colon (e.g. `CHECK-NEXT:   `), the parser previously validated
`if not arg:` before stripping whitespace. Because `arg` was non-empty
before stripping, it bypassed the empty check validation and was then
stripped to `""`. This produced an empty uop list that compiled to
`re.compile(r"^")`, which matched 0 characters at the current position
without advancing the input line, silently causing false-positive passes
on subsequent checks.

- parser: strip `arg` in non-strict-whitespace mode before checking for
  an empty check string (`if not arg:`).
- parser: report the check prefix (`{prefix}:`) rather than the
  directive kind (`{kind}:`) in the error message to match LLV
  FileCheck.
- parser: fall back to `match.start(2)` for the error column offset on
  plain `CHECK:` directives without a hyphenated suffix.
- tests: add diagnostics tests verifying that whitespace-only `CHECK:`
  and `CHECK-NEXT:` directives raise parse errors matching LLVM
  FileCheck.