### PR TITLE
Add explicit UTF-8 support for files and standard streams

### DIFF
--- a/filecheck/finput.py
+++ b/filecheck/finput.py
@@ -134,12 +134,16 @@ class FInput:
         """
         Create a FInput object from options objects
         """
-        # treat - as stding
+        # treat - as stdin
         if opts.input_file == "-":
-            f = sys.stdin
+            if hasattr(sys.stdin, "buffer"):
+                content = sys.stdin.buffer.read().decode("utf-8")
+            else:
+                content = sys.stdin.read()
         else:
-            f = open(opts.input_file, "r")
-        return FInput(opts.input_file, FInput.canonicalize_line_ends(f.read()))
+            with open(opts.input_file, "r", encoding="utf-8") as f:
+                content = f.read()
+        return FInput(opts.input_file, FInput.canonicalize_line_ends(content))
 
     def advance_by(self, dist: int):
         """

--- a/filecheck/main.py
+++ b/filecheck/main.py
@@ -1,3 +1,4 @@
+import io
 import sys
 import importlib.metadata
 
@@ -7,6 +8,12 @@ from filecheck.options import parse_argv_options
 
 
 def main(argv: list[str] | None = None):
+    for stream in (sys.stdout, sys.stderr):
+        if isinstance(stream, io.TextIOWrapper):
+            stream.reconfigure(
+                encoding="utf-8"
+            )  # pyright: ignore[reportUnknownMemberType]
+
     if argv is None:
         argv = sys.argv
 

--- a/filecheck/matcher.py
+++ b/filecheck/matcher.py
@@ -60,7 +60,7 @@ class Matcher:
     def __post_init__(self):
         self.ctx.live_variables.update(self.opts.variables)
         if self.opts.dump_input == DumpInputKind.NEVER:
-            self.stderr = open(os.devnull, "w")
+            self.stderr = open(os.devnull, "w", encoding="utf-8")
         else:
             self.stderr = sys.stderr
         if self.opts.dump_input in (DumpInputKind.ALWAYS, DumpInputKind.HELP):

--- a/filecheck/parser.py
+++ b/filecheck/parser.py
@@ -2,6 +2,7 @@
 parser for filecheck syntax
 """
 
+import io
 import re
 from dataclasses import dataclass, field
 from typing import Iterator, TextIO
@@ -78,7 +79,9 @@ class Parser(Iterator[CheckOp]):
 
     @classmethod
     def from_opts(cls, opts: Options):
-        return Parser(opts, open(opts.match_filename), *pattern_for_opts(opts))
+        with open(opts.match_filename, encoding="utf-8") as f:
+            content = f.read()
+        return Parser(opts, io.StringIO(content), *pattern_for_opts(opts))
 
     def __next__(self) -> CheckOp:
         """

--- a/tests/filecheck/diagnostics/utf8.test
+++ b/tests/filecheck/diagnostics/utf8.test
@@ -1,0 +1,6 @@
+// RUN: strip-comments.sh %s | exfail filecheck %s --allow-empty --comment-prefixes=RUN,COM,DIAG | filecheck %s --check-prefix DIAG
+
+foo 🚀 bar
+
+// CHECK: foo ❤ bar
+// DIAG: error: Couldn't match "foo ❤ bar"

--- a/tests/filecheck/utf8.test
+++ b/tests/filecheck/utf8.test
@@ -1,0 +1,7 @@
+// RUN: echo "foo ❤ 🗺️ bar" | filecheck %s
+// RUN: echo "prefix 日本語 測試 suffix" | filecheck %s --check-prefix=UNICODE
+// RUN: filecheck %s --input-file %s --check-prefix=SELF
+
+// CHECK: foo ❤ 🗺️ bar
+// UNICODE: prefix 日本語 測試 suffix
+// SELF: echo "foo ❤ 🗺️ bar"

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -1,0 +1,62 @@
+import io
+import sys
+import warnings
+from io import BytesIO
+from pathlib import Path
+import pytest
+from filecheck.matcher import Matcher
+from filecheck.options import DumpInputKind, Options
+
+
+def test_utf8_file_matching(tmp_path: Path):
+    check_file = tmp_path / "check.txt"
+    check_file.write_text(
+        "// CHECK: greeting: こんにちは 世界 🌍\n// CHECK-NEXT: math: α + β = γ\n",
+        encoding="utf-8",
+    )
+
+    input_file = tmp_path / "input.txt"
+    input_file.write_text(
+        "greeting: こんにちは 世界 🌍\nmath: α + β = γ\n",
+        encoding="utf-8",
+    )
+
+    opts = Options(match_filename=str(check_file), input_file=str(input_file))
+    matcher = Matcher.from_opts(opts)
+    assert matcher.run() == 0
+
+
+def test_utf8_stdin_matching(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    check_file = tmp_path / "check.txt"
+    check_file.write_text(
+        "// CHECK: emoji test: ❤ 🗺️ 🚀\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.TextIOWrapper(BytesIO("emoji test: ❤ 🗺️ 🚀\n".encode())),
+    )
+
+    opts = Options(match_filename=str(check_file), input_file="-")
+    matcher = Matcher.from_opts(opts)
+    assert matcher.run() == 0
+
+
+def test_no_encoding_warning(tmp_path: Path):
+    check_file = tmp_path / "check.txt"
+    check_file.write_text("// CHECK: plain ascii\n", encoding="utf-8")
+
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("plain ascii\n", encoding="utf-8")
+
+    opts = Options(
+        match_filename=str(check_file),
+        input_file=str(input_file),
+        dump_input=DumpInputKind.NEVER,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", EncodingWarning)
+        matcher = Matcher.from_opts(opts)
+        assert matcher.run() == 0


### PR DESCRIPTION
Ensure that filecheck consistently reads check-files, input files, and standard input as UTF-8 across platforms, avoiding locale-dependent encodings and silencing Python 3.10+ EncodingWarnings. Reconfigure stdout and stderr to UTF-8 in CLI mode to ensure diagnostic output containing multi-byte or Unicode characters is properly encoded.

- finput: Read input files using explicit utf-8 encoding within a context manager, and decode stdin from sys.stdin.buffer as utf-8.
- main: Reconfigure sys.stdout and sys.stderr to utf-8 when running from the CLI.
- matcher: Explicitly open /dev/null with utf-8 encoding when dump_input is set to NEVER.
- parser: Read check-files with explicit utf-8 encoding into a StringIO stream to ensure deterministic closing of file descriptors.
- tests: Add lit and pytest test cases covering UTF-8 matching in files, stdin, diagnostics, and verifying no EncodingWarnings are emitted.